### PR TITLE
Update npm utils version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-publish",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Poor man's semantic release utility. Let the CI do the `npm publish` step after the build passes",
   "main": "index.js",
   "bin": {
@@ -47,7 +47,7 @@
   "dependencies": {
     "available-versions": "0.13.2",
     "changed-log": "0.11.0",
-    "npm-utils": "1.7.1"
+    "npm-utils": "2.0.3"
   },
   "config": {
     "pre-git": {


### PR DESCRIPTION
With the newer npm-utils version, publishing to private npm repositories becomes possible by simply adding the following to a package.json
 "publishConfig": {
    "registry": "http://registry.notnpmjs.org"
  },